### PR TITLE
fix link to developer guide

### DIFF
--- a/index.html
+++ b/index.html
@@ -307,7 +307,7 @@
           <div class="span3">
             <h3>Places To Go</h3>
             <ul>
-              <li><a href="doc/developer_guide/index.html">Developer Guide</a></li>
+              <li><a href="https://enzo.readthedocs.io/en/latest/developer_guide/index.html">Developer Guide</a></li>
               <li><a href="https://github.com/enzo-project/enzo-dev/fork">Fork Enzo!</a></li>
               <li><a href="https://groups.google.com/forum/#!forum/enzo-dev">Dev Mailing List</a></li>
               <li><a href="https://github.com/enzo-project/enzo-dev/">Development Repository</a></li>


### PR DESCRIPTION
The link to the developer guide in the Enzo webpage gives a 404 error.  